### PR TITLE
Retain file extension in copy mode.

### DIFF
--- a/src/zzuf.c
+++ b/src/zzuf.c
@@ -47,6 +47,7 @@
 #include <string.h>
 #include <errno.h>
 #include <signal.h>
+#include <libgen.h>
 #if defined HAVE_SYS_TIME_H
 #   include <sys/time.h>
 #endif
@@ -730,7 +731,7 @@ static void spawn_children(zzuf_opts_t *opts)
         if (!tmpdir || !*tmpdir)
             tmpdir = "/tmp";
 
-        int k = 0;
+        int k = 0, extlen;
 
         for (int j = zz_optind + 1; j < opts->oldargc; ++j)
         {
@@ -738,12 +739,24 @@ static void spawn_children(zzuf_opts_t *opts)
             if (!fpin)
                 continue;
 
+            // Copy the path name since basename() might clobber it
+            char *tmpcopy = alloca(strlen(opts->oldargv[j])+1);
+            strcpy(tmpcopy, opts->oldargv[j]);
+            char *fbasename = basename(tmpcopy);
+            char *extension = strrchr(fbasename, '.');
+            if (!extension) {
+                extlen = 0;
+                extension = "";
+            }
+            else
+                extlen = strlen(extension);
+
 #ifdef _WIN32
             sprintf(tmpname, "%s/zzuf.%i.XXXXXX", tmpdir, GetCurrentProcessId());
             int fdout = _open(mktemp(tmpname), _O_RDWR, 0600);
 #else
-            sprintf(tmpname, "%s/zzuf.%i.XXXXXX", tmpdir, (int)getpid());
-            int fdout = mkstemp(tmpname);
+            sprintf(tmpname, "%s/zzuf.%i.XXXXXX%s", tmpdir, (int)getpid(), extension);
+            int fdout = mkstemps(tmpname, extlen);
 #endif
             if (fdout < 0)
             {

--- a/src/zzuf.c
+++ b/src/zzuf.c
@@ -48,6 +48,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <libgen.h>
+#include <alloca.h>
 #if defined HAVE_SYS_TIME_H
 #   include <sys/time.h>
 #endif


### PR DESCRIPTION
Some programs are picky about file extensions, and opmode copy wasn't preserving the extension when it copied the file. This change implements file extension preservation. We've been running this in BFF for a while now.

I believe this updated pull request fixes the concerns raised in the previous request.  In particular, it should work correctly when directory names include a period:

    ed@apple git:feature/retain_file_extension_in_copy_mode ~/Documents/2016/zzuf$ ./src/zzuf -O copy /bin/echo -- /tmp/foo.test
    -- /tmp/zzuf.16994.GnhRhy.test
    ed@apple git:feature/retain_file_extension_in_copy_mode ~/Documents/2016/zzuf$ ./src/zzuf -O copy /bin/echo -- /tmp/foo.test/another_test
    -- /tmp/zzuf.17011.b6q10e
    ed@apple git:feature/retain_file_extension_in_copy_mode ~/Documents/2016/zzuf$ ./src/zzuf -O copy /bin/echo -- /tmp/foo.test/another_test.ext 
    -- /tmp/zzuf.17025.gzC1lU.ext
