### PR TITLE
added _DEFAULT_SOURCE to fix compilation warnings on gcc 5

### DIFF
--- a/src/libzzuf/lib-mem.c
+++ b/src/libzzuf/lib-mem.c
@@ -20,6 +20,7 @@
 #define _GNU_SOURCE
 /* Need this for MAP_ANON and valloc() on FreeBSD (together with cdefs.h) */
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #if defined HAVE_SYS_CDEFS_H
 #   include <sys/cdefs.h>
 #endif

--- a/src/myfork.c
+++ b/src/myfork.c
@@ -19,6 +19,7 @@
 
 #define _INCLUDE_POSIX_SOURCE /* for STDERR_FILENO on HP-UX */
 #define _BSD_SOURCE /* for setenv on glibc systems */
+#define _DEFAULT_SOURCE
 
 #if defined HAVE_STDINT_H
 #   include <stdint.h>

--- a/src/zzuf.c
+++ b/src/zzuf.c
@@ -20,6 +20,7 @@
 #define _INCLUDE_POSIX_SOURCE /* for STDERR_FILENO on HP-UX */
 #define _POSIX_SOURCE /* for kill() on glibc systems */
 #define _BSD_SOURCE /* for setenv() on glibc systems */
+#define _DEFAULT_SOURCE
 
 #if defined HAVE_STDINT_H
 #   include <stdint.h>

--- a/test/bug-mmap.c
+++ b/test/bug-mmap.c
@@ -14,6 +14,7 @@
 #include "config.h"
 
 #define _BSD_SOURCE 1 /* for MAP_POPULATE */
+#define _DEFAULT_SOURCE
 
 #if HAVE_SYS_MMAN_H
 #   include <sys/mman.h>


### PR DESCRIPTION
To fix compilation warnings on GCC 5, you need to define _DEFAULT_SOURCE if _BSD_SOURCE is defined. This patch adds the necessary defines, to fix compilation warnings. 