### PR TITLE
Fix build on NetBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ AC_CHECK_HEADERS(unistd.h inttypes.h stdint.h endian.h libc.h)
 AC_CHECK_HEADERS(windows.h winsock2.h process.h)
 AC_CHECK_HEADERS(alloca.h malloc.h dlfcn.h regex.h sys/cdefs.h sys/socket.h)
 AC_CHECK_HEADERS(netinet/in.h arpa/inet.h sys/uio.h aio.h)
-AC_CHECK_HEADERS(sys/mman.h sys/wait.h sys/resource.h sys/time.h)
+AC_CHECK_HEADERS(sys/mman.h sys/wait.h sys/resource.h sys/select.h sys/time.h)
 AC_CHECK_HEADERS(io.h mach/task.h)
 
 AC_CHECK_FUNCS(setenv waitpid setrlimit gettimeofday fork kill pipe _pipe)

--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,7 @@ AC_CHECK_FUNCS(getopt_long)
 
 AC_CHECK_HEADERS(unistd.h inttypes.h stdint.h endian.h libc.h)
 AC_CHECK_HEADERS(windows.h winsock2.h process.h)
-AC_CHECK_HEADERS(malloc.h dlfcn.h regex.h sys/cdefs.h sys/socket.h)
+AC_CHECK_HEADERS(alloca.h malloc.h dlfcn.h regex.h sys/cdefs.h sys/socket.h)
 AC_CHECK_HEADERS(netinet/in.h arpa/inet.h sys/uio.h aio.h)
 AC_CHECK_HEADERS(sys/mman.h sys/wait.h sys/resource.h sys/time.h)
 AC_CHECK_HEADERS(io.h mach/task.h)

--- a/src/zzuf.c
+++ b/src/zzuf.c
@@ -52,6 +52,9 @@
 #if defined HAVE_ALLOCA_H
 #  include <alloca.h>
 #endif
+#if defined HAVE_SYS_SELECT_H
+#   include <sys/select.h>
+#endif
 #if defined HAVE_SYS_TIME_H
 #   include <sys/time.h>
 #endif

--- a/src/zzuf.c
+++ b/src/zzuf.c
@@ -49,7 +49,9 @@
 #include <errno.h>
 #include <signal.h>
 #include <libgen.h>
-#include <alloca.h>
+#if defined HAVE_ALLOCA_H
+#  include <alloca.h>
+#endif
 #if defined HAVE_SYS_TIME_H
 #   include <sys/time.h>
 #endif


### PR DESCRIPTION
Hi there, this is a build fix for NetBSD, where:
* <alloca.h> does not exist but alloca(3) is available in <stdlib.h> instead
* <sys/select.h> is not automatically visible
Cheers,
-- khorben