### PR TITLE
Fix SET and UNSET fuzzing modes

### DIFF
--- a/src/libzzuf/libzzuf.c
+++ b/src/libzzuf/libzzuf.c
@@ -148,6 +148,10 @@ void libzzuf_init(void)
     if (tmp && *tmp == '1')
         zzuf_set_auto_increment();
 
+    tmp = getenv("ZZUF_FUZZING");
+    if (tmp && *tmp)
+        _zz_fuzzing(tmp);
+
     tmp = getenv("ZZUF_BYTES");
     if (tmp && *tmp)
         _zz_bytes(tmp);


### PR DESCRIPTION
The `ZZUF_FUZZING` environment variable is being set by zzuf, but it's not being picked up by the injected library.  This pull request makes the library check for the environment variable and call `_zz_fuzzing` on the `ZZUF_FUZZING` value.