### PR TITLE
Printf uint32_t with PRIu32.

### DIFF
--- a/src/myfork.c
+++ b/src/myfork.c
@@ -21,10 +21,10 @@
 #define _BSD_SOURCE /* for setenv on glibc systems */
 #define _DEFAULT_SOURCE
 
-#if defined HAVE_STDINT_H
-#   include <stdint.h>
-#elif defined HAVE_INTTYPES_H
+#if defined HAVE_INTTYPES_H
 #   include <inttypes.h>
+#elif defined HAVE_STDINT_H
+#   include <stdint.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h> /* for setenv */
@@ -286,7 +286,11 @@ static int run_process(zzuf_child_t *child, zzuf_opts_t *opts, int pipes[][2])
     sprintf(buf, "%i", pipes[0][1]);
 #endif
     setenv("ZZUF_DEBUGFD", buf, 1);
-    sprintf(buf, "%i", opts->seed);
+#if defined HAVE_INTTYPES_H
+    sprintf(buf, "%"PRIu32, opts->seed);
+#else
+    sprintf(buf, "%u", opts->seed);
+#endif
     setenv("ZZUF_SEED", buf, 1);
     sprintf(buf, "%g", opts->minratio);
     setenv("ZZUF_MINRATIO", buf, 1);

--- a/src/zzuf.c
+++ b/src/zzuf.c
@@ -22,10 +22,10 @@
 #define _BSD_SOURCE /* for setenv() on glibc systems */
 #define _DEFAULT_SOURCE
 
-#if defined HAVE_STDINT_H
-#   include <stdint.h>
-#elif defined HAVE_INTTYPES_H
+#if defined HAVE_INTTYPES_H
 #   include <inttypes.h>
+#elif defined HAVE_STDINT_H
+#   include <stdint.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h>
@@ -654,10 +654,17 @@ static void loop_stdin(zzuf_opts_t *opts)
 static void finfo(FILE *fp, zzuf_opts_t *opts, uint32_t seed)
 {
     if (opts->minratio == opts->maxratio)
-        fprintf(fp, "zzuf[s=%i,r=%g]: ", seed, opts->minratio);
+#if defined HAVE_INTTYPES_H
+        fprintf(fp, "zzuf[s=%"PRIu32",r=%g]: ", seed, opts->minratio);
     else
-        fprintf(fp, "zzuf[s=%i,r=%g:%g]: ", seed,
+        fprintf(fp, "zzuf[s=%"PRIu32",r=%g:%g]: ", seed,
                 opts->minratio, opts->maxratio);
+#else
+        fprintf(fp, "zzuf[s=%u,r=%g]: ", seed, opts->minratio);
+    else
+        fprintf(fp, "zzuf[s=%u,r=%g:%g]: ", seed,
+                opts->minratio, opts->maxratio);
+#endif
 }
 
 #if defined HAVE_REGEX_H


### PR DESCRIPTION
This fixes Cppcheck complaining about printing it with an incorrect type.

The error Cppcheck gives about the unpatched code is:
`%i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.`

The error goes away when this patch is applied and Cppcheck is rerun.