### PR TITLE
Fix "implicit declaration of basename" warning.

### DIFF
--- a/src/zzuf.c
+++ b/src/zzuf.c
@@ -51,7 +51,9 @@
 #include <string.h>
 #include <errno.h>
 #include <signal.h>
-//#include <libgen.h>
+#ifndef _WIN32
+#include <libgen.h>
+#endif
 #if defined HAVE_ALLOCA_H
 #   include <alloca.h>
 #else


### PR DESCRIPTION
Compiling zzuf with gcc 7.5.0 on Windows Subsystem for Linux (openSUSE Leap 15.2) produces the following warning. This pull request fixes this warning by including `libgen.h` when compiling for non-Windows platforms (`#ifndef _WIN32`). The warning disappears when testing this pull request (with `make clean;make -j6 |& less` and typing /warning in less) on WSL Linux.

There were also some warnings about implicit declarations of `__fgets_chk`, `__fread_chk`, `__fread_unlocked_chk`, and `__fgets_unlocked_chk`. `stdio.h` (where __fgets_unlocked_chk should be according to [fgets-unlocked-chk-1.html](https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---fgets-unlocked-chk-1.html)) is included by zzuf.c though so I don't know why gcc says implicit declaration for these functions.
```
zzuf.c: In function ‘spawn_children’:
zzuf.c:769:31: warning: implicit declaration of function ‘basename’; did you mean ‘rename’? [-Wimplicit-function-declaration]
             char *fbasename = basename(tmpcopy);
                               ^~~~~~~~
                               rename
zzuf.c:769:31: warning: nested extern declaration of ‘basename’ [-Wnested-externs]
```